### PR TITLE
Used argparse for publisher CLI

### DIFF
--- a/ssh_key_rotator/publisher/key_publisher.py
+++ b/ssh_key_rotator/publisher/key_publisher.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import os
 import shutil
-import sys
+from argparse import ArgumentParser
 import boto3
 from ssh_key_rotator.custom_keygen import (
     generate_private_public_key_in_file,
@@ -65,21 +65,39 @@ class LocalPublisher(Publisher):
         return public_key.decode()
 
 
-if __name__ == "__main__":
-    command_line_arguments = sys.argv
-    user_flag_index = command_line_arguments.index("--user")
-    username = command_line_arguments[user_flag_index + 1]
-    server_flag_index = command_line_arguments.index("--server")
-    server = command_line_arguments[server_flag_index + 1]
-    data_store_flag_index = command_line_arguments.index("--datastore")
-    data_store = command_line_arguments[data_store_flag_index + 1]
+def create_argument_parser() -> ArgumentParser:
+    argument_parser = ArgumentParser(
+        prog="key_publisher",
+        description="Creates public/private SSH keys and publishes the public key either locally or to S3 (default is S3)",
+        epilog="Thanks for using key_publisher! :)",
+    )
 
-    if data_store == "local":
-        publisher = LocalPublisher(server, username)
+    parser.add_argument("user")
+    parser.add_argument("hostname")
+    parser.add_argument("-ds", "--datastore", choices=["s3", "local"], default="s3")
+
+    options = parser.add_argument_group("Options")
+    options.add_argument(
+        "-ds (s3 | local)",
+        "--datastore (s3 | local)",
+        help="choose where to store the public key, on S3 or on the local system (default is S3)"
+    )
+
+    arguments = parser.add_argument_group("Required Arguments")
+    arguments.add_argument("user")
+    arguments.add_argument("hostname")
+
+    return argument_parser
+
+
+if __name__ == "__main__":
+    parser = create_argument_parser()
+    args = parser.parse_args()
+
+    if args.datastore == "local":  # If the user chose to store the public key locally
+        publisher = LocalPublisher(args.hostname, args.user)
         publisher.publish_new_key()
-    elif data_store == "s3":
-        s3_bucket_name = input("Enter a bucket name: ")
-        publisher = S3Publisher(s3_bucket_name, server, username)
+    else:  # If the user chose to store the public key on S3 or chose to default to S3
+        s3_bucket_name = input("Enter an S3 bucket name: ")
+        publisher = S3Publisher(s3_bucket_name, args.hostname, args.user)
         publisher.publish_new_key()
-    else:
-        raise ValueError('Must specify either "local" or "s3" as the data store')


### PR DESCRIPTION
Used argparse instead of sys.argv for the publisher CLI
User must input their username and server hostname
User has the option to specify -ds/--datastore s3 or -ds/--datastore local. Default is s3.
If the user selects s3 or nothing, prompt them for bucket name