### PR TITLE
Publisher from command line

### DIFF
--- a/ssh_key_rotator/publisher/__main__.py
+++ b/ssh_key_rotator/publisher/__main__.py
@@ -1,0 +1,48 @@
+from argparse import ArgumentParser
+from ssh_key_rotator.publisher.key_publisher import LocalPublisher, S3Publisher
+
+
+def create_argument_parser() -> ArgumentParser:
+    argument_parser = ArgumentParser(
+        prog="key_publisher",
+        description="Creates public/private SSH keys and publishes "
+        + "the public key either locally or to S3 (default is S3)",
+        epilog="Thanks for using key_publisher! :)",
+    )
+
+    # argument_parser.add_argument("user")
+    # argument_parser.add_argument("hostname")
+    # argument_parser.add_argument("-ds", "--datastore", choices=["s3", "local"], default="s3")
+    arguments = argument_parser.add_argument_group("Required Arguments")
+    arguments.add_argument("hostname")
+    arguments.add_argument("user")
+
+    options = argument_parser.add_argument_group("Options")
+    options.add_argument(
+        "-ds",
+        "--datastore",
+        choices=["s3", "local"],
+        default="s3",
+        help="choose where to store the public key, on S3 or on the local system (default is S3)",
+    )
+    options.add_argument(
+        "--bucket",
+        required=False,
+        help="If s3 is selected, the bucket name to store the key in",
+    )
+
+    return argument_parser
+
+
+if __name__ == "__main__":
+    parser = create_argument_parser()
+    args = parser.parse_args()
+
+    if args.datastore == "local":  # If the user chose to store the public key locally
+        publisher = LocalPublisher(args.hostname, args.user)
+        publisher.publish_new_key()
+    else:  # If the user chose to store the public key on S3 or chose to default to S3
+        if args.bucket is None:
+            parser.error("The s3 option requires a bucket name!")
+        publisher = S3Publisher(args.bucket, args.hostname, args.user)
+        publisher.publish_new_key()

--- a/ssh_key_rotator/publisher/__main__.py
+++ b/ssh_key_rotator/publisher/__main__.py
@@ -10,22 +10,17 @@ def create_argument_parser() -> ArgumentParser:
         epilog="Thanks for using key_publisher! :)",
     )
 
-    # argument_parser.add_argument("user")
-    # argument_parser.add_argument("hostname")
-    # argument_parser.add_argument("-ds", "--datastore", choices=["s3", "local"], default="s3")
-    arguments = argument_parser.add_argument_group("Required Arguments")
-    arguments.add_argument("hostname")
-    arguments.add_argument("user")
+    argument_parser.add_argument("hostname")
+    argument_parser.add_argument("user")
 
-    options = argument_parser.add_argument_group("Options")
-    options.add_argument(
+    argument_parser.add_argument(
         "-ds",
         "--datastore",
         choices=["s3", "local"],
         default="s3",
         help="choose where to store the public key, on S3 or on the local system (default is S3)",
     )
-    options.add_argument(
+    argument_parser.add_argument(
         "--bucket",
         required=False,
         help="If s3 is selected, the bucket name to store the key in",

--- a/ssh_key_rotator/publisher/key_publisher.py
+++ b/ssh_key_rotator/publisher/key_publisher.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 import os
 import shutil
-from argparse import ArgumentParser
 import boto3
 from ssh_key_rotator.custom_keygen import (
     generate_private_public_key_in_file,
@@ -73,41 +72,3 @@ class LocalPublisher(Publisher):
             public_key_name=f"{self.user_id}-cert.pub",
         )
         return public_key.decode()
-
-
-def create_argument_parser() -> ArgumentParser:
-    argument_parser = ArgumentParser(
-        prog="key_publisher",
-        description="Creates public/private SSH keys and publishes the public key either locally or to S3 (default is S3)",
-        epilog="Thanks for using key_publisher! :)",
-    )
-
-    parser.add_argument("user")
-    parser.add_argument("hostname")
-    parser.add_argument("-ds", "--datastore", choices=["s3", "local"], default="s3")
-
-    options = parser.add_argument_group("Options")
-    options.add_argument(
-        "-ds (s3 | local)",
-        "--datastore (s3 | local)",
-        help="choose where to store the public key, on S3 or on the local system (default is S3)"
-    )
-
-    arguments = parser.add_argument_group("Required Arguments")
-    arguments.add_argument("user")
-    arguments.add_argument("hostname")
-
-    return argument_parser
-
-
-if __name__ == "__main__":
-    parser = create_argument_parser()
-    args = parser.parse_args()
-
-    if args.datastore == "local":  # If the user chose to store the public key locally
-        publisher = LocalPublisher(args.hostname, args.user)
-        publisher.publish_new_key()
-    else:  # If the user chose to store the public key on S3 or chose to default to S3
-        s3_bucket_name = input("Enter an S3 bucket name: ")
-        publisher = S3Publisher(s3_bucket_name, args.hostname, args.user)
-        publisher.publish_new_key()


### PR DESCRIPTION
- use python3.11 -m ssh_key_rotator.publisher [host] [user] -ds (s3/local) (optional) --bucket bucket-where-keys-are-stored
- Cleaned up argparser logic

closes #53 