### PR TITLE
Moved cloudwatch api tests to use temp files

### DIFF
--- a/tests/test_cloud_watch/file_metric_publisher.py
+++ b/tests/test_cloud_watch/file_metric_publisher.py
@@ -1,10 +1,10 @@
 """
 file_metric_publisher.py
 """
-
-import os
 import json
 from datetime import datetime
+from pathlib import Path
+from typing import Any
 from metric_system.functions.metrics import TimingMetric, CounterMetric
 from metric_system.functions.metric import Metric
 from metric_system.functions.metric_publisher import MetricPublisher
@@ -13,12 +13,10 @@ from metric_system.functions.metric_publisher import MetricPublisher
 class FileMetricPublisher(MetricPublisher):
     """Publishes specified metric data to a file"""
 
-    def __init__(self, name_space: str, instance_id: str):
+    def __init__(self, name_space: str, instance_id: str, file_location: Path):
         self.file_name = name_space
         self._instance_id = instance_id
-        self._file_location = (
-            os.getcwd() + "/tests/test_cloud_watch/FileMetricPublisherTest"
-        )
+        self._file_location = file_location
 
     def publish_metric(self, metric: Metric):
         """Publish metrics to a file"""
@@ -27,7 +25,7 @@ class FileMetricPublisher(MetricPublisher):
         metric_unit = metric.unit
         time = str(datetime.now().time())
 
-        data = {
+        data: Any = {
             "Metric Name": metric_name,
             "Metric Data": {
                 "Time Stamp": time,
@@ -37,12 +35,12 @@ class FileMetricPublisher(MetricPublisher):
         }
 
         if isinstance(metric, TimingMetric):
-            self.write_to_file(self._file_location + "/test_timeit.json", data)
+            self.write_to_file(Path(self._file_location / "test_timeit.json"), data)
         if isinstance(metric, CounterMetric):
-            self.write_to_file(self._file_location + "/test_inc_count.json", data)
+            self.write_to_file(Path(self._file_location / "test_inc_count.json"), data)
 
-    def write_to_file(self, file_path, content):
+    def write_to_file(self, file_path: Path, content: Any):
         """Write to file"""
-        with open(file_path, "w") as file:  # pylint: disable=unspecified-encoding
+        with open(file_path, "w+") as file:  # pylint: disable=unspecified-encoding
             # Write the JSON data to the file
             json.dump(content, file)


### PR DESCRIPTION
In the recent PR, in a merge conflict we removed files generated by the cloudwatch tests. The cloudwatch tests do not geenrate these automatically. While fixing that, I used pathlib and tempfiles to clean up the files generated