### PR TITLE
Remove-unused-parameters

### DIFF
--- a/metric_system/functions/aws_metric_publisher.py
+++ b/metric_system/functions/aws_metric_publisher.py
@@ -13,7 +13,6 @@ class AwsMetricPublisher(MetricPublisher):
 
         Args:
             name_space (str): The namespace of the metric.
-            aws_region (str): The AWS region to use for CloudWatch.
         """
         self._name_space: str = name_space
         self.cloud_watch: Client = boto3.client("cloudwatch")  # type: ignore #pylint: disable = line-too-long

--- a/metric_system/functions/aws_metric_publisher.py
+++ b/metric_system/functions/aws_metric_publisher.py
@@ -1,5 +1,4 @@
 """AWS metric publisher"""
-from datetime import datetime
 import boto3
 from mypy_boto3_cloudwatch import Client
 from metric_system.functions.metric_publisher import MetricPublisher
@@ -9,18 +8,15 @@ from metric_system.functions.metric import Metric
 class AwsMetricPublisher(MetricPublisher):
     """Publishes Metric-specific data"""
 
-    def __init__(self, name_space: str, instance_id: str, aws_region: str):
+    def __init__(self, name_space: str):
         """Instantiate the AWSMetricPublisher object.
 
         Args:
             name_space (str): The namespace of the metric.
-            instance_id (str): The ID of the instance associated with the metric.
             aws_region (str): The AWS region to use for CloudWatch.
         """
         self._name_space: str = name_space
-        self.cloud_watch: Client = boto3.client("cloudwatch", region_name=aws_region)  # type: ignore #pylint: disable = line-too-long
-        self._instance_id: str = instance_id
-        self.time_of_init: datetime = datetime.now()
+        self.cloud_watch: Client = boto3.client("cloudwatch")  # type: ignore #pylint: disable = line-too-long
 
     def publish_metric(self, metric: Metric):
         """Publishes a metric to CloudWatch.
@@ -36,13 +32,6 @@ class AwsMetricPublisher(MetricPublisher):
         self.cloud_watch.put_metric_data(
             Namespace=self._name_space,
             MetricData=[
-                {
-                    "MetricName": metric_name,
-                    "Dimensions": [
-                        {"Name": metric_name + "AWS_MetricPublisher", "Value": "AWS"},
-                    ],
-                    "Unit": metric_unit,
-                    "Value": metric_value,
-                },
+                {"MetricName": metric_name, "Unit": metric_unit, "Value": metric_value},
             ],
         )

--- a/metric_system/functions/file_metric_publisher.py
+++ b/metric_system/functions/file_metric_publisher.py
@@ -72,6 +72,8 @@ class FileMetricPublisher(MetricPublisher):
 
     def __init__(self, metric_dir: Path):
         self._metric_dir = metric_dir
+        if not metric_dir.exists():
+            metric_dir.mkdir(parents=True, exist_ok=True)
 
     def _metric_file_path(self, metric_name: str):
         return self._metric_dir / f"{metric_name}.json"


### PR DESCRIPTION
- removed instance id and region from AWS Publisher. Instance id because it was not doing anything, and region because we are using the region in the aws config

- removed dimension from AWS publisher - global metrics