### PR TITLE
Metric-api-retrieve

### DIFF
--- a/metric_system/functions/aws_metric_publisher.py
+++ b/metric_system/functions/aws_metric_publisher.py
@@ -1,4 +1,5 @@
 """AWS metric publisher"""
+from datetime import datetime, timezone
 import boto3
 from mypy_boto3_cloudwatch import Client
 from metric_system.functions.metric_publisher import MetricPublisher
@@ -31,6 +32,12 @@ class AwsMetricPublisher(MetricPublisher):
         self.cloud_watch.put_metric_data(
             Namespace=self._name_space,
             MetricData=[
-                {"MetricName": metric_name, "Unit": metric_unit, "Value": metric_value},
+                {
+                    "MetricName": metric_name,
+                    "Timestamp": datetime.now(timezone.utc),
+                    "Unit": metric_unit,
+                    "Value": metric_value,
+                    "StorageResolution": 1,
+                },
             ],
         )

--- a/metric_system/functions/file_metric_publisher.py
+++ b/metric_system/functions/file_metric_publisher.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from metric_system.functions.metric import Metric
 from metric_system.functions.metric_publisher import MetricPublisher
-from metric_system.functions.metric import MetricJsonData, DataPoint
+from metric_system.functions.metric import MetricData, DataPoint
 
 
 class FileMetricPublisher(MetricPublisher):
@@ -32,7 +32,7 @@ class FileMetricPublisher(MetricPublisher):
         # Check if we already have data published to the file
         retrieved_data = self.retrieve_metric_data(metric.name)
         if retrieved_data is None:
-            retrieved_data = MetricJsonData(metric_name=metric.name, data_points=[])
+            retrieved_data = MetricData(metric_name=metric.name, data_points=[])
         retrieved_data.data_points.append(new_datapoint)
         # Write to file
         with open(
@@ -41,11 +41,11 @@ class FileMetricPublisher(MetricPublisher):
             # Write the JSON data to the file
             json.dump(retrieved_data.to_json(), file)
 
-    def retrieve_metric_data(self, metric_name: str) -> MetricJsonData | None:
+    def retrieve_metric_data(self, metric_name: str) -> MetricData | None:
         try:
             with open(
                 self._metric_file_path(metric_name), encoding="utf-8", mode="rt"
             ) as data_file:
-                return MetricJsonData.from_json(json.load(data_file))
+                return MetricData.from_json(json.load(data_file))
         except FileNotFoundError:
             return None

--- a/metric_system/functions/file_metric_publisher.py
+++ b/metric_system/functions/file_metric_publisher.py
@@ -1,70 +1,11 @@
 """
 file_metric_publisher.py
 """
-from dataclasses import dataclass
 import json
-from datetime import datetime
 from pathlib import Path
-from typing import Any
-from mypy_boto3_cloudwatch.literals import StandardUnitType
 from metric_system.functions.metric import Metric
 from metric_system.functions.metric_publisher import MetricPublisher
-
-
-@dataclass
-class DataPoint:
-    timestamp: datetime
-    unit: StandardUnitType
-    value: float
-
-    @classmethod
-    def create_from(cls, metric: Metric):
-        return DataPoint(datetime.now(), metric.unit, metric.value)
-
-
-@dataclass
-class MetricJsonData:
-    metric_name: str
-    data_points: list[DataPoint]
-
-    @classmethod
-    def from_json(cls, obj: Any):
-        "Parses the JSON representation of this class into an instance of this class"
-        # Ensure that we have our attributes
-        if not "metric_name" in obj or not "data_points" in obj:
-            raise TypeError("Error deserializing metric data!")
-        metric_name = obj["metric_name"]
-        data_points_json = obj["data_points"]
-
-        # Maps data point json => data point object, erroring out if needed
-        def map_data_points(data_point: Any) -> DataPoint:
-            if not all(
-                ["timestamp" in data_point, "unit" in data_point, "value" in data_point]
-            ):
-                raise TypeError("Error deserializing metric data!")
-            timestamp = datetime.strptime(
-                data_point["timestamp"], "%Y-%m-%d %H:%M:%S.%f"
-            )
-            unit = data_point["unit"]
-            value = float(data_point["value"])
-            return DataPoint(timestamp, unit, value)
-
-        # Call the mapping function
-        data_points = list(map(map_data_points, data_points_json))
-        return MetricJsonData(metric_name, data_points)
-
-    def to_json(self) -> Any:
-        "Makes this object JSON-serializable by treating the data points as dicts"
-
-        def data_point_to_json(data_point: DataPoint):
-            return {
-                "timestamp": str(data_point.timestamp),
-                "unit": data_point.unit,
-                "value": data_point.value,
-            }
-
-        data_points = list(map(data_point_to_json, self.data_points))
-        return {"metric_name": self.metric_name, "data_points": data_points}
+from metric_system.functions.metric import MetricJsonData, DataPoint
 
 
 class FileMetricPublisher(MetricPublisher):

--- a/metric_system/functions/file_metric_publisher.py
+++ b/metric_system/functions/file_metric_publisher.py
@@ -3,6 +3,7 @@ file_metric_publisher.py
 """
 import json
 from pathlib import Path
+from datetime import datetime
 from metric_system.functions.metric import Metric
 from metric_system.functions.metric_publisher import MetricPublisher
 from metric_system.functions.metric import MetricData, DataPoint
@@ -30,9 +31,7 @@ class FileMetricPublisher(MetricPublisher):
         # Create our new datapoint
         new_datapoint = DataPoint.create_from(metric)
         # Check if we already have data published to the file
-        retrieved_data = self.retrieve_metric_data(metric.name)
-        if retrieved_data is None:
-            retrieved_data = MetricData(metric_name=metric.name, data_points=[])
+        retrieved_data = self._retrieve_all_data(metric.name)
         retrieved_data.data_points.append(new_datapoint)
         # Write to file
         with open(
@@ -41,11 +40,31 @@ class FileMetricPublisher(MetricPublisher):
             # Write the JSON data to the file
             json.dump(retrieved_data.to_json(), file)
 
-    def retrieve_metric_data(self, metric_name: str) -> MetricData | None:
+    def retrieve_metric_data(
+        self, metric_name: str, start_time: datetime, end_time: datetime
+    ) -> MetricData:
+        all_data = self._retrieve_all_data(metric_name)
+        datapoints_in_timeframe: list[DataPoint] = []
+        found_beginning = False
+        for datapoint in all_data.data_points:
+            if not found_beginning:
+                if datapoint.timestamp >= start_time:
+                    datapoints_in_timeframe.append(
+                        datapoint
+                    )  # First datapoint in range
+            else:  # Keep appending as long as we havent hit the end
+                if datapoint.timestamp > end_time:
+                    break
+                datapoints_in_timeframe.append(
+                    datapoint
+                )  # Have not hit the end just yet
+        return MetricData(metric_name, datapoints_in_timeframe)
+
+    def _retrieve_all_data(self, metric_name: str) -> MetricData:
         try:
             with open(
                 self._metric_file_path(metric_name), encoding="utf-8", mode="rt"
             ) as data_file:
                 return MetricData.from_json(json.load(data_file))
         except FileNotFoundError:
-            return None
+            return MetricData(metric_name, [])

--- a/metric_system/functions/file_metric_publisher.py
+++ b/metric_system/functions/file_metric_publisher.py
@@ -3,10 +3,8 @@ file_metric_publisher.py
 """
 import json
 from pathlib import Path
-from datetime import datetime
-from metric_system.functions.metric import Metric
+from metric_system.functions.metric import Metric, DataPoint, MetricData
 from metric_system.functions.metric_publisher import MetricPublisher
-from metric_system.functions.metric import MetricData, DataPoint
 
 
 class FileMetricPublisher(MetricPublisher):
@@ -39,26 +37,6 @@ class FileMetricPublisher(MetricPublisher):
         ) as file:
             # Write the JSON data to the file
             json.dump(retrieved_data.to_json(), file)
-
-    def retrieve_metric_data(
-        self, metric_name: str, start_time: datetime, end_time: datetime
-    ) -> MetricData:
-        all_data = self._retrieve_all_data(metric_name)
-        datapoints_in_timeframe: list[DataPoint] = []
-        found_beginning = False
-        for datapoint in all_data.data_points:
-            if not found_beginning:
-                if datapoint.timestamp >= start_time:
-                    datapoints_in_timeframe.append(
-                        datapoint
-                    )  # First datapoint in range
-            else:  # Keep appending as long as we havent hit the end
-                if datapoint.timestamp > end_time:
-                    break
-                datapoints_in_timeframe.append(
-                    datapoint
-                )  # Have not hit the end just yet
-        return MetricData(metric_name, datapoints_in_timeframe)
 
     def _retrieve_all_data(self, metric_name: str) -> MetricData:
         try:

--- a/metric_system/functions/metric.py
+++ b/metric_system/functions/metric.py
@@ -55,7 +55,7 @@ class DataPoint:
 
 
 @dataclass
-class MetricJsonData:
+class MetricData:
     metric_name: str
     data_points: list[DataPoint]
 
@@ -83,7 +83,7 @@ class MetricJsonData:
 
         # Call the mapping function
         data_points = list(map(map_data_points, data_points_json))
-        return MetricJsonData(metric_name, data_points)
+        return MetricData(metric_name, data_points)
 
     def to_json(self) -> Any:
         "Makes this object JSON-serializable by treating the data points as dicts"

--- a/metric_system/functions/metric.py
+++ b/metric_system/functions/metric.py
@@ -50,6 +50,10 @@ class DataPoint:
     value: float
 
     @classmethod
+    def parse_timestamp(cls, str_timestamp: str) -> datetime:
+        return datetime.strptime(str_timestamp, "%Y-%m-%d %H:%M:%S.%f")
+
+    @classmethod
     def create_from(cls, metric: Metric):
         return DataPoint(datetime.now(), metric.unit, metric.value)
 
@@ -74,9 +78,7 @@ class MetricData:
                 ["timestamp" in data_point, "unit" in data_point, "value" in data_point]
             ):
                 raise TypeError("Error deserializing metric data!")
-            timestamp = datetime.strptime(
-                data_point["timestamp"], "%Y-%m-%d %H:%M:%S.%f"
-            )
+            timestamp = DataPoint.parse_timestamp(data_point["timestamp"])
             unit = data_point["unit"]
             value = float(data_point["value"])
             return DataPoint(timestamp, unit, value)

--- a/metric_system/functions/metric.py
+++ b/metric_system/functions/metric.py
@@ -1,5 +1,7 @@
 from abc import ABC
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 from mypy_boto3_cloudwatch.literals import StandardUnitType
 
 
@@ -39,3 +41,59 @@ class Metric(ABC):
     @property
     def metric_init_time(self) -> datetime:
         return self._metric_init
+
+
+@dataclass
+class DataPoint:
+    timestamp: datetime
+    unit: StandardUnitType
+    value: float
+
+    @classmethod
+    def create_from(cls, metric: Metric):
+        return DataPoint(datetime.now(), metric.unit, metric.value)
+
+
+@dataclass
+class MetricJsonData:
+    metric_name: str
+    data_points: list[DataPoint]
+
+    @classmethod
+    def from_json(cls, obj: Any):
+        "Parses the JSON representation of this class into an instance of this class"
+        # Ensure that we have our attributes
+        if not "metric_name" in obj or not "data_points" in obj:
+            raise TypeError("Error deserializing metric data!")
+        metric_name = obj["metric_name"]
+        data_points_json = obj["data_points"]
+
+        # Maps data point json => data point object, erroring out if needed
+        def map_data_points(data_point: Any) -> DataPoint:
+            if not all(
+                ["timestamp" in data_point, "unit" in data_point, "value" in data_point]
+            ):
+                raise TypeError("Error deserializing metric data!")
+            timestamp = datetime.strptime(
+                data_point["timestamp"], "%Y-%m-%d %H:%M:%S.%f"
+            )
+            unit = data_point["unit"]
+            value = float(data_point["value"])
+            return DataPoint(timestamp, unit, value)
+
+        # Call the mapping function
+        data_points = list(map(map_data_points, data_points_json))
+        return MetricJsonData(metric_name, data_points)
+
+    def to_json(self) -> Any:
+        "Makes this object JSON-serializable by treating the data points as dicts"
+
+        def data_point_to_json(data_point: DataPoint):
+            return {
+                "timestamp": str(data_point.timestamp),
+                "unit": data_point.unit,
+                "value": data_point.value,
+            }
+
+        data_points = list(map(data_point_to_json, self.data_points))
+        return {"metric_name": self.metric_name, "data_points": data_points}

--- a/metric_system/functions/metric_publisher.py
+++ b/metric_system/functions/metric_publisher.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from metric_system.functions.metric import Metric
+from datetime import datetime
+from metric_system.functions.metric import Metric, MetricData
 
 
 class MetricPublisher(ABC):
@@ -10,3 +11,17 @@ class MetricPublisher(ABC):
         Args:
             metric (Metric): The metric object to be published.
         """
+
+    @abstractmethod
+    def retrieve_metric_data(
+        self, metric_name: str, start_time: datetime, end_time: datetime
+    ) -> MetricData:
+        """Retrieves a metrics data within a given timeframe as a list of time-marked data points
+
+        Args:
+            metric_name (str): The metric to retrieve data from
+            start_time: (datetime): when to start the timeframe of data
+            end_time (datetime): when to end the timeframe of data
+
+        Returns:
+            metric_data (MetricData): The metric data"""

--- a/metric_system/functions/metric_publisher.py
+++ b/metric_system/functions/metric_publisher.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
-from metric_system.functions.metric import Metric, MetricData
+from metric_system.functions.metric import Metric
 
 
 class MetricPublisher(ABC):
@@ -11,17 +10,3 @@ class MetricPublisher(ABC):
         Args:
             metric (Metric): The metric object to be published.
         """
-
-    @abstractmethod
-    def retrieve_metric_data(
-        self, metric_name: str, start_time: datetime, end_time: datetime
-    ) -> MetricData:
-        """Retrieves a metrics data within a given timeframe as a list of time-marked data points
-
-        Args:
-            metric_name (str): The metric to retrieve data from
-            start_time: (datetime): when to start the timeframe of data
-            end_time (datetime): when to end the timeframe of data
-
-        Returns:
-            metric_data (MetricData): The metric data"""

--- a/tests/test_cloud_watch/cloudwatch/conftest.py
+++ b/tests/test_cloud_watch/cloudwatch/conftest.py
@@ -1,0 +1,40 @@
+# pyright: reportUnknownVariableType=false
+import time
+import pytest
+from metric_system.functions.metrics import CounterMetric, TimingMetric
+from metric_system.functions.aws_metric_publisher import AwsMetricPublisher
+from tests.test_cloud_watch.retrievers.cloudwatch import AWSMetricRetriever
+
+
+@pytest.fixture(name="namespace", scope="session")
+def fixture_namespace() -> str:
+    "The namespace we will be working with for testing"
+    return "switcheroo-test"
+
+
+@pytest.fixture(scope="session")
+def cw_publisher(namespace: str) -> AwsMetricPublisher:
+    "CloudWatch publisher for the namespace defined above"
+    return AwsMetricPublisher(name_space=namespace)
+
+
+@pytest.fixture(scope="session")
+def cw_retriever(namespace: str) -> AWSMetricRetriever:
+    "Cloudwatch retriever for the namespace defined above"
+    return AWSMetricRetriever(name_space=namespace)
+
+
+@pytest.fixture
+def counting_metric() -> CounterMetric:
+    return CounterMetric("test_counter", "Count")
+
+
+@pytest.fixture
+def timing_metric() -> TimingMetric:
+    return TimingMetric("test_timer", "Seconds")
+
+
+@pytest.fixture(autouse=True)
+def sleep_a_second():
+    "We want to wait a second after every CW test to ensure metrics are separate"
+    time.sleep(1)

--- a/tests/test_cloud_watch/cloudwatch/test_cloudwatch_publish.py
+++ b/tests/test_cloud_watch/cloudwatch/test_cloudwatch_publish.py
@@ -1,0 +1,73 @@
+import time
+from datetime import datetime, timezone, timedelta
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_length,
+    greater_than_or_equal_to,
+    less_than_or_equal_to,
+)
+from metric_system.functions.aws_metric_publisher import AwsMetricPublisher
+from metric_system.functions.metrics import CounterMetric
+from tests.test_cloud_watch.retrievers.cloudwatch import AWSMetricRetriever
+
+
+def test_publish_and_retrieve(
+    cw_publisher: AwsMetricPublisher,
+    cw_retriever: AWSMetricRetriever,
+    counting_metric: CounterMetric,
+):
+    "Publish a few values to cloudwatch and retrieve"
+    # Store the current time - know when to get the metrics from
+    current_time = datetime.now(timezone.utc)
+    # Publish values 0-5
+    for _ in range(0, 5):
+        cw_publisher.publish_metric(counting_metric)
+        counting_metric.increment()
+        time.sleep(1)
+    # Store end time
+    end_time = datetime.now(timezone.utc)
+    time.sleep(1)
+    # Retrieve the metric datapoints
+    retrieved_data = cw_retriever.retrieve_metric_data(
+        metric_name=counting_metric.name,
+        start_time=current_time,
+        end_time=end_time,
+        unit="Seconds",
+    )
+    expected_datapoints = set(range(0, 5))
+    actual_datapoints = set(
+        map(lambda datapoint: datapoint.value, retrieved_data.data_points)
+    )
+    assert_that(actual_datapoints, equal_to(expected_datapoints))
+
+
+def test_publish_time(
+    cw_publisher: AwsMetricPublisher,
+    cw_retriever: AWSMetricRetriever,
+    counting_metric: CounterMetric,
+):
+    """The AWS publisher should publish metric at the timestamp of when publish is called."""
+    # AWS timestamps do not have microseconds, so we'll floor the time to the nearest second
+    # We cant get the time exactly, but a leeway of 3 seconds should do, even if floored
+    current_time = datetime.now(timezone.utc).replace(microsecond=0)
+    expected_max_time = (datetime.now(timezone.utc) + timedelta(seconds=2)).replace(
+        microsecond=0
+    )
+    # Publish the metric
+    cw_publisher.publish_metric(counting_metric)
+    time.sleep(1)
+    retrieved_data = cw_retriever.retrieve_metric_data(
+        metric_name=counting_metric.name,
+        start_time=current_time,
+        end_time=expected_max_time,
+        unit=counting_metric.unit,
+    )
+    # First ensure this is the metric we published - didn't pick up any extras
+    assert_that(retrieved_data.data_points, has_length(1))
+    retrieved_metric = retrieved_data.data_points[0]
+    # Ensure value is the one we published
+    assert_that(retrieved_metric.value, equal_to(counting_metric.value))
+    # Ensure that the timeframe is within our bounds
+    assert_that(retrieved_metric.timestamp, greater_than_or_equal_to(current_time))
+    assert_that(retrieved_metric.timestamp, less_than_or_equal_to(expected_max_time))

--- a/tests/test_cloud_watch/retrievers/__init__.py
+++ b/tests/test_cloud_watch/retrievers/__init__.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+from pathlib import Path
+from abc import ABC, abstractmethod
+import json
+from mypy_boto3_cloudwatch.literals import StandardUnitType
+from metric_system.functions.metric import MetricData, DataPoint
+
+
+class MetricRetriever(ABC):
+    @abstractmethod
+    def retrieve_metric_data(
+        self,
+        metric_name: str,
+        start_time: datetime,
+        end_time: datetime,
+        unit: StandardUnitType,
+    ) -> MetricData:
+        """Retrieves all metric data of the metric with the given name between the start & end time.
+        This disregards the unit of the metric."""
+
+
+class FileMetricRetriever(MetricRetriever):
+    """
+    Retrieves metric data from files.
+    This class is purely for testing purposes - the functionality of CloudWatch is very vast,
+    using this as a general retrieve method would be limiting.
+    """
+
+    def __init__(self, metric_dir: Path) -> None:
+        self._metric_dir = metric_dir
+
+    def retrieve_metric_data(
+        self,
+        metric_name: str,
+        start_time: datetime,
+        end_time: datetime,
+        unit: StandardUnitType,
+    ) -> MetricData:
+        all_data = self._retrieve_all_data(metric_name)
+        datapoints_in_timeframe: list[DataPoint] = []
+        found_beginning = False
+        for datapoint in all_data.data_points:
+            if not found_beginning:
+                if datapoint.timestamp >= start_time:
+                    datapoints_in_timeframe.append(
+                        datapoint
+                    )  # First datapoint in range
+            else:  # Keep appending as long as we havent hit the end
+                if datapoint.timestamp > end_time:
+                    break
+                # Check if the unit is what we passed in
+                if datapoint.unit == unit:
+                    datapoints_in_timeframe.append(
+                        datapoint
+                    )  # Have not hit the end just yet
+        return MetricData(metric_name, datapoints_in_timeframe)
+
+    def _retrieve_all_data(self, metric_name: str) -> MetricData:
+        try:
+            with open(
+                self._metric_dir / f"{metric_name}.json", encoding="utf-8", mode="rt"
+            ) as data_file:
+                return MetricData.from_json(json.load(data_file))
+        except FileNotFoundError:
+            return MetricData(metric_name, [])

--- a/tests/test_cloud_watch/retrievers/cloudwatch.py
+++ b/tests/test_cloud_watch/retrievers/cloudwatch.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+import boto3
+from mypy_boto3_cloudwatch import Client
+from mypy_boto3_cloudwatch.literals import StandardUnitType
+from metric_system.functions.metric import MetricData, DataPoint
+
+
+class AWSMetricRetriever:
+    def __init__(self, name_space: str):
+        self._name_space: str = name_space
+        self._cloud_watch: Client = boto3.client("cloudwatch")  # type: ignore
+
+    def retrieve_metric_data(
+        self,
+        metric_name: str,
+        start_time: datetime,
+        end_time: datetime,
+        unit: StandardUnitType,
+    ) -> MetricData:
+        """Returns metric data from CloudWatch"""
+        response = self._cloud_watch.get_metric_data(
+            MetricDataQueries=[
+                {
+                    "Id": "some_id",  # Does not have to be unique
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": self._name_space,
+                            "MetricName": metric_name,
+                        },
+                        "Period": 1,
+                        "Stat": "Sum",
+                    },
+                    "ReturnData": True,
+                }
+            ],
+            StartTime=start_time,
+            EndTime=end_time,
+        )
+        results = response["MetricDataResults"][0]
+        datapoints = list(
+            zip(results["Timestamps"], results["Values"])  # pyright: ignore
+        )
+
+        # Convert datapoint results to metric data
+        def res_to_dp(datapoint_info: tuple[datetime, float]):
+            return DataPoint(datapoint_info[0], unit, datapoint_info[1])
+
+        metric_data = MetricData(metric_name, list(map(res_to_dp, datapoints)))
+        return metric_data

--- a/tests/test_cloud_watch/test_file_publish_api.py
+++ b/tests/test_cloud_watch/test_file_publish_api.py
@@ -8,10 +8,8 @@ import math
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from hamcrest import assert_that, equal_to, has_length
-from metric_system.functions.file_metric_publisher import (
-    FileMetricPublisher,
-    MetricJsonData,
-)
+from metric_system.functions.file_metric_publisher import FileMetricPublisher
+from metric_system.functions.metric import MetricJsonData
 from metric_system.functions.metrics import TimingMetric, CounterMetric
 
 

--- a/tests/test_cloud_watch/test_file_publish_api.py
+++ b/tests/test_cloud_watch/test_file_publish_api.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from pathlib import Path
 from hamcrest import assert_that, equal_to, has_length
 from metric_system.functions.file_metric_publisher import FileMetricPublisher
-from metric_system.functions.metric import MetricJsonData
+from metric_system.functions.metric import MetricData
 from metric_system.functions.metrics import TimingMetric, CounterMetric
 
 
@@ -38,7 +38,7 @@ class PublisherAPITest(unittest.TestCase):
         """
         self.increment_count_metric()
         self.publisher.publish_metric(self.inc_key_count_metric)
-        data: MetricJsonData | None = self.publisher.retrieve_metric_data(
+        data: MetricData | None = self.publisher.retrieve_metric_data(
             self.inc_key_count_metric.name
         )
         assert data is not None

--- a/tests/test_cloud_watch/test_file_publish_api.py
+++ b/tests/test_cloud_watch/test_file_publish_api.py
@@ -9,9 +9,11 @@ from tempfile import TemporaryDirectory
 from datetime import datetime, timedelta
 from pathlib import Path
 from hamcrest import assert_that, equal_to, has_length
+from mypy_boto3_cloudwatch.literals import StandardUnitType
 from metric_system.functions.file_metric_publisher import FileMetricPublisher
 from metric_system.functions.metric import MetricData
 from metric_system.functions.metrics import TimingMetric, CounterMetric
+from tests.test_cloud_watch.retrievers import FileMetricRetriever
 
 
 class PublisherAPITest(unittest.TestCase):
@@ -26,6 +28,7 @@ class PublisherAPITest(unittest.TestCase):
         self.enterContext(temp_dir)
         self._file_location = Path(temp_dir.name)
         self.publisher = FileMetricPublisher(metric_dir=self._file_location)
+        self.retriever = FileMetricRetriever(metric_dir=self._file_location)
         self.inc_key_count_metric = CounterMetric(
             metric_name="File Test Counter", unit="Count"
         )
@@ -40,7 +43,7 @@ class PublisherAPITest(unittest.TestCase):
         self.increment_count_metric()
         self.publisher.publish_metric(self.inc_key_count_metric)
         data: MetricData | None = self.retrieve_all_test_data(
-            self.inc_key_count_metric.name
+            self.inc_key_count_metric.name, "Count"
         )
         assert data is not None
         assert_that(self.count_int, equal_to(data.data_points[0].value))
@@ -51,7 +54,7 @@ class PublisherAPITest(unittest.TestCase):
         """
         self.time_key()
         self.publisher.publish_metric(self.time_metric)
-        data = self.retrieve_all_test_data(self.time_metric.name)
+        data = self.retrieve_all_test_data(self.time_metric.name, "Seconds")
         assert data is not None
         assert_that(
             self.time_to_generate_int, equal_to(math.floor(data.data_points[0].value))
@@ -63,12 +66,12 @@ class PublisherAPITest(unittest.TestCase):
         """
         self.increment_count_metric()
         self.publisher.publish_metric(self.inc_key_count_metric)
-        data = self.retrieve_all_test_data(self.inc_key_count_metric.name)
+        data = self.retrieve_all_test_data(self.inc_key_count_metric.name, "Count")
         assert data is not None
         assert_that(data.data_points, has_length(1))
         self.increment_count_metric()
         self.publisher.publish_metric(self.inc_key_count_metric)
-        data2 = self.retrieve_all_test_data(self.inc_key_count_metric.name)
+        data2 = self.retrieve_all_test_data(self.inc_key_count_metric.name, "Count")
         assert data2 is not None
         assert_that(data2.data_points, has_length(2))
         assert_that(data.data_points[0].value, equal_to(self.count_int))
@@ -81,15 +84,16 @@ class PublisherAPITest(unittest.TestCase):
             self.publisher.publish_metric(self.inc_key_count_metric)
         # Get all data
         all_data = self.retrieve_all_test_data(
-            self.inc_key_count_metric.name
+            self.inc_key_count_metric.name, unit="Seconds"
         ).data_points
         # Get their timestamps
         data_timestamps = list(map(lambda datapoint: datapoint.timestamp, all_data))
         # Retrieve between the middle 2 timestamps
-        middle_data = self.publisher.retrieve_metric_data(
+        middle_data = self.retriever.retrieve_metric_data(
             self.inc_key_count_metric.name,
             start_time=data_timestamps[1],
             end_time=data_timestamps[2],
+            unit="Count",
         ).data_points
         assert_that(middle_data[0], equal_to(all_data[1]))
         assert_that(middle_data[1], equal_to(all_data[2]))
@@ -108,12 +112,15 @@ class PublisherAPITest(unittest.TestCase):
         with self.time_metric.timeit():
             time.sleep(self.time_to_generate_int)
 
-    def retrieve_all_test_data(self, metric_name: str) -> MetricData:
+    def retrieve_all_test_data(
+        self, metric_name: str, unit: StandardUnitType
+    ) -> MetricData:
         # Presumably our tests dont take a day to finish, so this should get all data
-        return self.publisher.retrieve_metric_data(
+        return self.retriever.retrieve_metric_data(
             metric_name,
             start_time=datetime.now() - timedelta(days=1),
             end_time=datetime.now() + timedelta(days=1),
+            unit=unit,
         )
 
 


### PR DESCRIPTION
- moved all retriever functionality into the test module - the flexibility on retrieve provided by boto3 is too much to encapsulate in this API (yet). For testing purposes we can set certain values (ie period=1)

- Implemented tests for cloudwatch publisher

-created fixtures for cloudwatch metric api tests